### PR TITLE
feat: load attractions from backend and redesign menu toggle

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -382,6 +382,14 @@ async def get_leaderboard():
     leaderboard.sort(key=lambda x: x["score"], reverse=True)
     return leaderboard[:10]  # Top 10
 
+# Attractions endpoint
+@app.get("/attractions")
+async def get_attractions():
+    """Return tourism attractions grouped by district."""
+    data_path = os.path.join(os.path.dirname(__file__), "data", "attractions.json")
+    with open(data_path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
 # Chatbot endpoints
 @app.get("/chatbot/info")
 async def get_chatbot_info():

--- a/Backend/data/attractions.json
+++ b/Backend/data/attractions.json
@@ -1,0 +1,50 @@
+{
+  "Kota Kinabalu": {
+    "description": "Capital city of Sabah, known for its vibrant markets and waterfront.",
+    "attractions": [
+      {"name": "Gaya Street", "desc": "Famous Sunday market with local food, crafts, and souvenirs.", "image": "/jumbah image/gaya street.JPG"},
+      {"name": "Signal Hill Observatory", "desc": "Best city view and sunset spot in Kota Kinabalu.", "image": "/jumbah image/gunung kinabalu.jpg"},
+      {"name": "Sabah Art Gallery", "desc": "Modern art museum showcasing local artists.", "image": "/jumbah image/sabah-art-gallery.jpg"},
+      {"name": "Muzium Sabah", "desc": "Museum of Sabah's history and culture.", "image": "/jumbah image/Muzium Sabah.jpg"},
+      {"name": "Tanjung Aru Beach", "desc": "Popular beach for sunset and picnics.", "image": "/jumbah image/Tanjung Aru.jpg"}
+    ],
+    "stamps": [
+      {"id": 1, "name": "Gaya Street Stamp", "location": "Gaya Street"},
+      {"id": 2, "name": "Signal Hill Stamp", "location": "Signal Hill Observatory"},
+      {"id": 3, "name": "Art Gallery Stamp", "location": "Sabah Art Gallery"},
+      {"id": 4, "name": "Museum Stamp", "location": "Muzium Sabah"},
+      {"id": 5, "name": "Tanjung Aru Stamp", "location": "Tanjung Aru Beach"}
+    ]
+  },
+  "Kinabatangan": {
+    "description": "Home to the Kinabatangan River and amazing wildlife experiences.",
+    "attractions": [
+      {"name": "Kinabatangan River Cruise", "desc": "River cruise for wildlife spotting: proboscis monkeys, orangutans, and more.", "image": "/jumbah image/kinabatangan river cruise.jpg"},
+      {"name": "Poring Hot Springs", "desc": "Natural hot springs and canopy walk.", "image": "/jumbah image/poring2.jpg"},
+      {"name": "Mari Mari Cultural Village", "desc": "Experience traditional Sabahan culture and food.", "image": "/jumbah image/mari2 cv.jpg"}
+    ],
+    "stamps": [
+      {"id": 6, "name": "River Cruise Stamp", "location": "Kinabatangan River"},
+      {"id": 7, "name": "Poring Stamp", "location": "Poring Hot Springs"},
+      {"id": 8, "name": "Mari Mari Stamp", "location": "Mari Mari Cultural Village"}
+    ]
+  },
+  "Sipadan": {
+    "description": "World-famous diving destination with crystal clear waters.",
+    "attractions": [
+      {"name": "Pulau Sipadan", "desc": "Top diving spot in Malaysia, known for turtles and barracuda.", "image": "/jumbah image/pulau sipadan.jpg"}
+    ],
+    "stamps": [
+      {"id": 9, "name": "Sipadan Stamp", "location": "Pulau Sipadan"}
+    ]
+  },
+  "Tawau": {
+    "description": "Gateway to Tawau Hills Park and lush rainforest.",
+    "attractions": [
+      {"name": "Tawau Hills Park", "desc": "Rainforest park with waterfalls and giant trees.", "image": "/jumbah image/tawau hills.jfif"}
+    ],
+    "stamps": [
+      {"id": 10, "name": "Tawau Hills Stamp", "location": "Tawau Hills Park"}
+    ]
+  }
+}

--- a/Frontend/src/components/DropdownMenu.jsx
+++ b/Frontend/src/components/DropdownMenu.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import {
-  FaEllipsisV,
+  FaBars,
   FaMoon,
   FaSun,
   FaCog,
@@ -77,41 +77,41 @@ const DropdownMenu = () => {
     navigate("/profile");
   };
 
-  const menuItems = [
-    {
-      icon: FaMap,
-      label: "Interactive Map",
-      to: "/map",
-      color: "#4285f4",
-    },
-    {
-      icon: FaLanguage,
-      label: "Bahasa Malaysia Translator",
-      onClick: handleItemClick,
-      color: "#34a853",
-    },
-  ];
+const menuItems = [
+  {
+    icon: <FaMap />,
+    label: "Interactive Map",
+    to: "/map",
+    color: "#4285f4",
+  },
+  {
+    icon: <FaLanguage />,
+    label: "Bahasa Malaysia Translator",
+    onClick: handleItemClick,
+    color: "#34a853",
+  },
+];
 
-  const authenticatedItems = [
-    {
-      icon: FaUser,
-      label: "My Profile",
-      to: "/profile",
-      color: "#6366f1",
-    },
-    {
-      icon: FaTrophy,
-      label: "My Adventures",
-      to: "/adventure",
-      color: "#f59e0b",
-    },
-    {
-      icon: FaCog,
-      label: "Settings",
-      to: "/settings",
-      color: "#6b7280",
-    },
-  ];
+const authenticatedItems = [
+  {
+    icon: <FaUser />,
+    label: "My Profile",
+    to: "/profile",
+    color: "#6366f1",
+  },
+  {
+    icon: <FaTrophy />,
+    label: "My Adventures",
+    to: "/adventure",
+    color: "#f59e0b",
+  },
+  {
+    icon: <FaCog />,
+    label: "Settings",
+    to: "/settings",
+    color: "#6b7280",
+  },
+];
 
   return (
     <div className="dropdown-container">
@@ -122,8 +122,8 @@ const DropdownMenu = () => {
         onClick={() => (isOpen ? handleClose() : handleOpen())}
         aria-label="Open menu"
       >
-        <FaEllipsisV />
-      </button>
+          <FaBars />
+        </button>
 
       {/* Backdrop */}
       {isOpen && (
@@ -262,7 +262,7 @@ const DropdownMenu = () => {
   );
 };
 
-const MenuItem = ({ icon: Icon, label, to, onClick, color }) => {
+const MenuItem = ({ icon, label, to, onClick, color }) => {
   const navigate = useNavigate();
 
   const handleClick = () => {
@@ -275,7 +275,7 @@ const MenuItem = ({ icon: Icon, label, to, onClick, color }) => {
   return (
     <button className="menu-item" onClick={handleClick}>
       <div className="menu-item-content">
-        <Icon style={{ color }} />
+        {React.cloneElement(icon, { style: { color } })}
         <span>{label}</span>
       </div>
     </button>

--- a/Frontend/src/pages/ExplorePage.jsx
+++ b/Frontend/src/pages/ExplorePage.jsx
@@ -1,113 +1,29 @@
 import { useParams, useLocation } from "react-router-dom";
-// Embedded districts data
-const districts = {
-  "Kota Kinabalu": {
-    description:
-      "Capital city of Sabah, known for its vibrant markets and waterfront.",
-    attractions: [
-      {
-        name: "Gaya Street",
-        desc: "Famous Sunday market with local food, crafts, and souvenirs.",
-        image: "/jumbah image/gaya street.JPG",
-      },
-      {
-        name: "Signal Hill Observatory",
-        desc: "Best city view and sunset spot in Kota Kinabalu.",
-        image: "/jumbah image/gunung kinabalu.jpg",
-      },
-      {
-        name: "Sabah Art Gallery",
-        desc: "Modern art museum showcasing local artists.",
-        image: "/jumbah image/sabah-art-gallery.jpg",
-      },
-      {
-        name: "Muzium Sabah",
-        desc: "Museum of Sabah's history and culture.",
-        image: "/jumbah image/Muzium Sabah.jpg",
-      },
-      {
-        name: "Tanjung Aru Beach",
-        desc: "Popular beach for sunset and picnics.",
-        image: "/jumbah image/Tanjung Aru.jpg",
-      },
-    ],
-    stamps: [
-      { id: 1, name: "Gaya Street Stamp", location: "Gaya Street" },
-      { id: 2, name: "Signal Hill Stamp", location: "Signal Hill Observatory" },
-      { id: 3, name: "Art Gallery Stamp", location: "Sabah Art Gallery" },
-      { id: 4, name: "Museum Stamp", location: "Muzium Sabah" },
-      { id: 5, name: "Tanjung Aru Stamp", location: "Tanjung Aru Beach" },
-    ],
-  },
-  Kinabatangan: {
-    description:
-      "Home to the Kinabatangan River and amazing wildlife experiences.",
-    attractions: [
-      {
-        name: "Kinabatangan River Cruise",
-        desc: "River cruise for wildlife spotting: proboscis monkeys, orangutans, and more.",
-        image: "/jumbah image/kinabatangan river cruise.jpg",
-      },
-      {
-        name: "Poring Hot Springs",
-        desc: "Natural hot springs and canopy walk.",
-        image: "/jumbah image/poring2.jpg",
-      },
-      {
-        name: "Mari Mari Cultural Village",
-        desc: "Experience traditional Sabahan culture and food.",
-        image: "/jumbah image/mari2 cv.jpg",
-      },
-    ],
-    stamps: [
-      { id: 6, name: "River Cruise Stamp", location: "Kinabatangan River" },
-      { id: 7, name: "Poring Stamp", location: "Poring Hot Springs" },
-      {
-        id: 8,
-        name: "Mari Mari Stamp",
-        location: "Mari Mari Cultural Village",
-      },
-    ],
-  },
-  Sipadan: {
-    description: "World-famous diving destination with crystal clear waters.",
-    attractions: [
-      {
-        name: "Pulau Sipadan",
-        desc: "Top diving spot in Malaysia, known for turtles and barracuda.",
-        image: "/jumbah image/pulau sipadan.jpg",
-      },
-    ],
-    stamps: [{ id: 9, name: "Sipadan Stamp", location: "Pulau Sipadan" }],
-  },
-  Tawau: {
-    description: "Gateway to Tawau Hills Park and lush rainforest.",
-    attractions: [
-      {
-        name: "Tawau Hills Park",
-        desc: "Rainforest park with waterfalls and giant trees.",
-        image: "/jumbah image/tawau hills.jfif",
-      },
-    ],
-    stamps: [
-      { id: 10, name: "Tawau Hills Stamp", location: "Tawau Hills Park" },
-    ],
-  },
-};
+import { useEffect, useState } from "react";
 import { useGame } from "../contexts/GameContext";
 import { useAuth } from "../contexts/AuthContext";
 import "../styles/ExplorePage.css";
 
+const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000";
+
 const ExplorePage = () => {
+  const [districts, setDistricts] = useState({});
   const { districtName } = useParams();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
-  const district = searchParams.get("district");
   const attractionQuery = searchParams.get("attraction");
   const formattedName = districtName.replace(/-/g, " ");
   const districtData = districts[formattedName];
   const { isAuthenticated } = useAuth();
   const { collectStamp, collectedStamps } = useGame();
+
+  useEffect(() => {
+    fetch(`${API_BASE}/attractions`)
+      .then((res) => res.json())
+      .then((data) => setDistricts(data))
+      .catch((err) => console.error("Failed to load attractions", err));
+  }, []);
+
   // Find the attraction if query param is present
   const foundAttraction =
     attractionQuery && districtData
@@ -115,6 +31,14 @@ const ExplorePage = () => {
           (a) => a.name.toLowerCase() === attractionQuery.toLowerCase()
         )
       : null;
+
+  if (Object.keys(districts).length === 0) {
+    return (
+      <div className="container">
+        <h2>Loading attractions...</h2>
+      </div>
+    );
+  }
 
   if (!districtData) {
     return (
@@ -128,7 +52,7 @@ const ExplorePage = () => {
     <div className="explorePage">
       <header
         className="header"
-        style={{ backgroundImage: `url(${districtData.attractions[1].image})` }}
+        style={{ backgroundImage: `url(${districtData.attractions[0].image})` }}
       >
         <div className="headerOverlay"></div>
         <div className="headerContent">

--- a/Frontend/src/styles/DropdownMenu.css
+++ b/Frontend/src/styles/DropdownMenu.css
@@ -5,45 +5,24 @@
 
 /* Toggle Button */
 .dropdown-toggle {
-  background: none;
+  background: linear-gradient(135deg, #667eea, #764ba2);
   border: none;
-  color: #6b7280;
+  color: #ffffff;
   font-size: 1.2rem;
   cursor: pointer;
-  padding: 12px;
-  border-radius: 12px;
-  transition: all 0.2s ease;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
-  overflow: hidden;
-}
-
-.dropdown-toggle:before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: linear-gradient(
-    135deg,
-    rgba(99, 102, 241, 0.1),
-    rgba(168, 85, 247, 0.1)
-  );
-  opacity: 0;
-  transition: opacity 0.2s ease;
-  border-radius: 12px;
-}
-
-.dropdown-toggle:hover:before {
-  opacity: 1;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .dropdown-toggle:hover {
-  color: #4f46e5;
-  transform: translateY(-1px);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
 }
 
 /* Backdrop */


### PR DESCRIPTION
## Summary
- add attractions API endpoint backed by JSON data
- fetch attraction data in ExplorePage for dynamic updates
- restyle navbar sidebar toggle with gradient hamburger button for clearer access

## Testing
- `python -m pytest`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68abf1847f388324923b450536705b62