### PR TITLE
Add ORM-backed score and chat session handling

### DIFF
--- a/Backend/chat_utils.py
+++ b/Backend/chat_utils.py
@@ -1,0 +1,17 @@
+import json
+from typing import List, Dict
+from sqlalchemy.orm import Session
+from models import ChatSession
+
+
+def fetch_recent_history(
+    db: Session, session_id: str, limit: int = 8
+) -> List[Dict[str, str]]:
+    """Return the most recent messages for a chat session."""
+    chat_session = (
+        db.query(ChatSession).filter_by(session_id=session_id).first()
+    )
+    if not chat_session or not chat_session.messages:
+        return []
+    messages = json.loads(chat_session.messages)
+    return messages[-limit:]

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -1,0 +1,21 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+BASE_DIR = os.path.dirname(__file__)
+DB_PATH = os.path.join(BASE_DIR, 'instance', 'jumbah.db')
+SQLALCHEMY_DATABASE_URL = f'sqlite:///{DB_PATH}'
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={'check_same_thread': False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/Backend/migrations/versions/e3b1c53f8a3a_add_chat_session_and_username.py
+++ b/Backend/migrations/versions/e3b1c53f8a3a_add_chat_session_and_username.py
@@ -1,0 +1,33 @@
+"""add chat session and username to score
+
+Revision ID: e3b1c53f8a3a
+Revises: 8bc83ae4e44e
+Create Date: 2024-06-01 00:00:00.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = 'e3b1c53f8a3a'
+down_revision = '8bc83ae4e44e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('score', sa.Column('username', sa.String(length=80), nullable=False))
+    op.create_table(
+        'chat_session',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('session_id', sa.String(length=36), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=True),
+        sa.Column('messages', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('last_activity', sa.DateTime(), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('session_id')
+    )
+
+
+def downgrade():
+    op.drop_table('chat_session')
+    op.drop_column('score', 'username')

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+import json
+from sqlalchemy import Column, Integer, String, DateTime, Text
+from database import Base
+
+
+class Score(Base):
+    __tablename__ = 'score'
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, nullable=False)
+    username = Column(String(80), nullable=False)
+    score = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+
+class ChatSession(Base):
+    __tablename__ = 'chat_session'
+
+    id = Column(Integer, primary_key=True, index=True)
+    session_id = Column(String(36), unique=True, nullable=False)
+    user_id = Column(Integer, nullable=True)
+    messages = Column(Text, default='[]')
+    created_at = Column(DateTime, default=datetime.utcnow)
+    last_activity = Column(DateTime, default=datetime.utcnow)
+
+    def append_messages(self, new_messages):
+        data = json.loads(self.messages or '[]')
+        data.extend(new_messages)
+        self.messages = json.dumps(data)

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -4,6 +4,8 @@ uvicorn[standard]==0.24.0
 python-dotenv==1.0.0
 pydantic==2.5.0
 google-generativeai==0.3.2
+SQLAlchemy==2.0.29
+alembic==1.13.1
 
 # Optional: for production deployment
 gunicorn==21.2.0


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for `Score` and `ChatSession`
- migrate database to include chat sessions and username on scores
- refactor scores, leaderboard, and chatbot endpoints to use the ORM
- add helper to fetch recent chat history

## Testing
- `python -m py_compile Backend/app.py Backend/models.py Backend/chat_utils.py Backend/database.py`
- `cd Backend && pytest`
- `cd Backend && flake8 app.py models.py chat_utils.py database.py` *(fails: many style issues in app.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ac3fff873c8324b9a443d516b7f7d0