### PR TITLE
Add PostgreSQL-backed user and score storage

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -13,6 +13,11 @@ from dotenv import load_dotenv
 import google.generativeai as genai
 import jwt
 from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from database import Base, engine, get_db
+from models import User, Score
 
 # Load environment variables
 load_dotenv()
@@ -49,11 +54,12 @@ JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY", "your-super-secret-key-change-in-pr
 JWT_ALGORITHM = "HS256"
 JWT_EXPIRATION_HOURS = 24
 
-# In-memory storage (replace with database in production)
-users_db: Dict[str, Dict[str, Any]] = {}
+# Initialize database
+Base.metadata.create_all(bind=engine)
+
+# In-memory storage for chat sessions only
 chat_sessions: Dict[str, List[Dict[str, Any]]] = {}
 user_contexts: Dict[str, Dict[str, Any]] = {}
-user_scores: Dict[str, List[Dict[str, Any]]] = {}
 
 # Pydantic models
 class UserRegister(BaseModel):
@@ -299,49 +305,48 @@ async def health_check():
 
 # Authentication endpoints
 @app.post("/register")
-async def register(user_data: UserRegister):
-    if user_data.username in users_db:
+async def register(user_data: UserRegister, db: Session = Depends(get_db)):
+    existing_user = db.query(User).filter(User.username == user_data.username).first()
+    if existing_user:
         raise HTTPException(status_code=400, detail="Username already exists")
-    
+
     hashed_password = pwd_context.hash(user_data.password)
-    user_id = str(uuid.uuid4())
-    
-    users_db[user_data.username] = {
-        "user_id": user_id,
-        "username": user_data.username,
-        "password": hashed_password,
-        "created_at": datetime.now().isoformat()
-    }
-    
-    user_scores[user_id] = []
-    
-    return {"message": "User registered successfully", "user_id": user_id}
+    user = User(username=user_data.username, password=hashed_password)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    return {"message": "User registered successfully", "user_id": user.id}
+
 
 @app.post("/login")
-async def login(user_data: UserLogin):
-    user = users_db.get(user_data.username)
-    if not user or not pwd_context.verify(user_data.password, user["password"]):
+async def login(user_data: UserLogin, db: Session = Depends(get_db)):
+    user = db.query(User).filter(User.username == user_data.username).first()
+    if not user or not pwd_context.verify(user_data.password, user.password):
         raise HTTPException(status_code=401, detail="Invalid username or password")
-    
+
     access_token = create_access_token({
-        "username": user["username"],
-        "user_id": user["user_id"]
+        "username": user.username,
+        "user_id": user.id
     })
-    
+
     return {
         "access_token": access_token,
         "token_type": "bearer",
         "user": {
-            "username": user["username"],
-            "user_id": user["user_id"]
+            "username": user.username,
+            "user_id": user.id
         }
     }
 
 @app.get("/profile")
-async def get_profile(current_user: dict = Depends(verify_token)):
+async def get_profile(current_user: dict = Depends(verify_token), db: Session = Depends(get_db)):
+    user = db.get(User, current_user["user_id"])
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
     return {
-        "username": current_user["username"],
-        "user_id": current_user["user_id"],
+        "username": user.username,
+        "user_id": user.id,
         "message": "Profile retrieved successfully"
     }
 
@@ -351,35 +356,29 @@ async def get_quiz():
     return {"questions": quiz_questions}
 
 @app.post("/scores")
-async def submit_score(score_data: ScoreSubmission, current_user: dict = Depends(verify_token)):
-    user_id = current_user["user_id"]
-    
-    if user_id not in user_scores:
-        user_scores[user_id] = []
-    
-    user_scores[user_id].append({
-        "score": score_data.score,
-        "timestamp": datetime.now().isoformat(),
-        "username": current_user["username"]
-    })
-    
+async def submit_score(
+    score_data: ScoreSubmission,
+    current_user: dict = Depends(verify_token),
+    db: Session = Depends(get_db),
+):
+    score = Score(user_id=current_user["user_id"], score=score_data.score)
+    db.add(score)
+    db.commit()
     return {"message": "Score submitted successfully", "score": score_data.score}
 
+
 @app.get("/leaderboard")
-async def get_leaderboard():
-    leaderboard = []
-    
-    for user_id, scores in user_scores.items():
-        if scores:
-            max_score = max(score["score"] for score in scores)
-            username = scores[0]["username"]  # Get username from first score
-            leaderboard.append({
-                "username": username,
-                "score": max_score
-            })
-    
-    # Sort by score descending
-    leaderboard.sort(key=lambda x: x["score"], reverse=True)
+async def get_leaderboard(db: Session = Depends(get_db)):
+    results = (
+        db.query(User.username, func.max(Score.score).label("score"))
+        .join(Score)
+        .group_by(User.id)
+        .order_by(func.max(Score.score).desc())
+        .all()
+    )
+    leaderboard = [
+        {"username": username, "score": score} for username, score in results
+    ]
     return leaderboard[:10]  # Top 10
 
 # Chatbot endpoints

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -1,0 +1,21 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///instance/jumbah.db")
+
+# SQLite needs a special flag for multithreading
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+
+from database import Base
+
+
+class User(Base):
+    __tablename__ = "user"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String(80), unique=True, nullable=False)
+    password = Column(String(120), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    scores = relationship("Score", back_populates="user", cascade="all, delete-orphan")
+
+
+class Score(Base):
+    __tablename__ = "score"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("user.id"), nullable=False)
+    score = Column(Integer, nullable=False)
+    timestamp = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="scores")

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -6,6 +6,9 @@ pydantic==2.5.0
 google-generativeai==0.3.2
 requests==2.31.0
 beautifulsoup4==4.12.2
+sqlalchemy==2.0.23
+alembic==1.12.1
+psycopg2-binary==2.9.9
 
 # Optional: for production deployment
 gunicorn==21.2.0
@@ -13,5 +16,4 @@ gunicorn==21.2.0
 # Development tools
 pytest==7.4.3
 black==23.11.0
-flake8==6.1.0
 flake8==6.1.0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
 Main JumBah
+
+## Backend Setup
+
+The backend is built with **FastAPI** and uses **PostgreSQL** (or SQLite for development) to
+store user accounts and game scores. The database connection is configured via the
+`DATABASE_URL` environment variable. If not provided, a local SQLite database in
+`Backend/instance/jumbah.db` is used.
+
+### Quick Start
+
+1. Create and activate a Python virtual environment.
+2. Install backend dependencies:
+
+   ```bash
+   pip install -r Backend/requirements.txt
+   ```
+
+3. Set the database URL (example for PostgreSQL):
+
+   ```bash
+   export DATABASE_URL=postgresql://user:password@localhost:5432/jumbah
+   ```
+
+4. Run the API:
+
+   ```bash
+   uvicorn Backend.app:app --reload
+   ```
+
+### Game Endpoints
+
+- `POST /scores` – submit a score for the authenticated user.
+- `GET /leaderboard` – view the top scores.
+
+These endpoints allow you to build an interactive points-based game on top of the
+travel chatbot.


### PR DESCRIPTION
## Summary
- introduce SQLAlchemy database layer for persistence
- persist users and game scores in PostgreSQL/SQLite
- document backend setup and game endpoints

## Testing
- `pytest`
- `flake8 Backend/app.py Backend/models.py Backend/database.py --exclude .venv`

------
https://chatgpt.com/codex/tasks/task_e_68ad1d2d7c00832489fae402ea0f772c