### PR TITLE
Add Splide slider to upcoming events page

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -5,13 +5,18 @@
     <link
       rel="icon"
       type="image/svg+xml"
-      href="public\backgrounds\sunbear.jpg"
+      href="public\\backgrounds\\sunbear.jpg"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/css/splide.min.css"
     />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>JumBah</title>
   </head>
   <body>
     <div id="root"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@splidejs/splide@4.1.4/dist/js/splide.min.js"></script>
     <script type="module" src="/src/main.jsx"></script>
   </body>
 </html>

--- a/Frontend/src/data/events.js
+++ b/Frontend/src/data/events.js
@@ -1,23 +1,31 @@
+import placeholder from '../assets/littlegirl.jpg';
+
 export const upcomingEvents = [
-    {
-        id: 1,
-        title: "Kaamatan Festival Finale",
-        date: "May 30-31, 2026",
-        location: "KDCA, Penampang",
-        description: "Experience the grand finale of Sabah's most important cultural harvest festival with traditional music, dance, and food."
-    },
-    {
-        id: 2,
-        title: "Regatta Lepa Semporna",
-        date: "April 19-21, 2026",
-        location: "Semporna",
-        description: "A spectacular festival of decorated traditional sailing boats from the Bajau Laut community."
-    },
-    {
-        id: 3,
-        title: "Borneo Arts Festival",
-        date: "September 5-7, 2025",
-        location: "Kota Kinabalu",
-        description: "A celebration of local and regional art, featuring exhibitions, workshops, and performances."
-    }
+  {
+    id: 1,
+    title: 'Kaamatan Festival Finale',
+    date: 'May 30-31, 2026',
+    location: 'KDCA, Penampang',
+    description:
+      "Experience the grand finale of Sabah's most important cultural harvest festival with traditional music, dance, and food.",
+    image: placeholder,
+  },
+  {
+    id: 2,
+    title: 'Regatta Lepa Semporna',
+    date: 'April 19-21, 2026',
+    location: 'Semporna',
+    description:
+      'A spectacular festival of decorated traditional sailing boats from the Bajau Laut community.',
+    image: placeholder,
+  },
+  {
+    id: 3,
+    title: 'Borneo Arts Festival',
+    date: 'September 5-7, 2025',
+    location: 'Kota Kinabalu',
+    description:
+      'A celebration of local and regional art, featuring exhibitions, workshops, and performances.',
+    image: placeholder,
+  },
 ];

--- a/Frontend/src/pages/EventsPage.jsx
+++ b/Frontend/src/pages/EventsPage.jsx
@@ -1,26 +1,54 @@
-import React from "react";
+/* global Splide */
+import React, { useEffect, useRef } from "react";
 import { upcomingEvents } from "../data/events";
 import "../styles/EventsPage.css";
 
 const EventsPage = () => {
+  const splideRef = useRef(null);
+
+  useEffect(() => {
+    if (splideRef.current) {
+      const splide = new Splide(splideRef.current, {
+        type: "loop",
+        perPage: 3,
+        gap: "1rem",
+        breakpoints: {
+          1024: { perPage: 2 },
+          640: { perPage: 1 },
+        },
+      });
+      splide.mount();
+    }
+  }, []);
+
   return (
     <div className="container eventsPage">
       <h1>Current & Upcoming Events</h1>
       <p>
-        Immerse yourself in the vibrant culture of Sabah. Here's what's
-        happening!
+        Immerse yourself in the vibrant culture of Sabah. Here's what's happening!
       </p>
-      <div className="eventList">
-        {upcomingEvents.map((event) => (
-          <div key={event.id} className="eventCard">
-            <div className="eventInfo">
-              <span className="eventDate">{event.date}</span>
-              <h2 className="eventTitle">{event.title}</h2>
-              <p className="eventLocation">{event.location}</p>
-              <p className="eventDescription">{event.description}</p>
-            </div>
-          </div>
-        ))}
+      <div className="splide" ref={splideRef}>
+        <div className="splide__track">
+          <ul className="splide__list">
+            {upcomingEvents.map((event) => (
+              <li key={event.id} className="splide__slide">
+                <div className="eventCard">
+                  <img
+                    src={event.image}
+                    alt={event.title}
+                    className="eventImage"
+                  />
+                  <div className="eventInfo">
+                    <span className="eventDate">{event.date}</span>
+                    <h2 className="eventTitle">{event.title}</h2>
+                    <p className="eventLocation">{event.location}</p>
+                    <p className="eventDescription">{event.description}</p>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
       </div>
     </div>
   );

--- a/Frontend/src/styles/EventsPage.css
+++ b/Frontend/src/styles/EventsPage.css
@@ -6,10 +6,6 @@
   margin-bottom: 3rem;
   font-size: 1.2rem;
 }
-.eventList {
-  display: grid;
-  gap: 2rem;
-}
 .eventCard {
   background: var(--surface-color);
   border-left: 5px solid var(--primary-color);
@@ -35,4 +31,16 @@
   font-style: italic;
   color: var(--text-secondary);
   margin: 0.5rem 0;
+}
+
+.eventImage {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+}
+
+.splide {
+  margin-top: 2rem;
 }


### PR DESCRIPTION
## Summary
- integrate Splide slider for upcoming events with images
- load Splide assets from CDN
- style event cards and images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 21 errors, 1 warning)

------
https://chatgpt.com/codex/tasks/task_e_68ad3142df608324b812b2771c6eeb8a