### PR TITLE
Add weather widget to homepage

### DIFF
--- a/Frontend/src/components/WeatherWidget.jsx
+++ b/Frontend/src/components/WeatherWidget.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import "../styles/WeatherWidget.css";
+
+const API_KEY = import.meta.env.VITE_OPENWEATHER_API_KEY;
+
+const WeatherWidget = () => {
+  const [weather, setWeather] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchWeather = async () => {
+      if (!API_KEY) {
+        setError("Missing API key");
+        return;
+      }
+      try {
+        const response = await fetch(
+          `https://api.openweathermap.org/data/2.5/weather?q=Kota+Kinabalu&units=metric&appid=${API_KEY}`
+        );
+        if (!response.ok) {
+          throw new Error("Failed to fetch weather");
+        }
+        const data = await response.json();
+        setWeather({
+          temp: data.main.temp,
+          condition: data.weather[0].description,
+        });
+      } catch (err) {
+        setError(err.message);
+      }
+    };
+
+    fetchWeather();
+  }, []);
+
+  return (
+    <div className="weatherWidget">
+      <h3>Current Weather</h3>
+      {error && <p className="error">{error}</p>}
+      {!error && !weather && <p>Loading...</p>}
+      {weather && (
+        <>
+          <p className="temp">{Math.round(weather.temp)}°C</p>
+          <p className="condition">{weather.condition}</p>
+        </>
+      )}
+      <p className="seasonNote">
+        Ideal visiting season: March to May and September.
+      </p>
+    </div>
+  );
+};
+
+export default WeatherWidget;

--- a/Frontend/src/pages/HomePage.jsx
+++ b/Frontend/src/pages/HomePage.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { districts } from "../data/attractions";
 import { upcomingEvents } from "../data/events";
 import { FaArrowRight } from "react-icons/fa";
+import WeatherWidget from "../components/WeatherWidget";
 
 // Import Swiper for sliding feature (run: npm install swiper)
 import { Swiper, SwiperSlide } from "swiper/react";
@@ -26,6 +27,7 @@ const HomePage = () => {
             Start Your Adventure
           </Link>
         </div>
+        <WeatherWidget />
       </header>
 
       {/* Explore Districts Section */}

--- a/Frontend/src/styles/WeatherWidget.css
+++ b/Frontend/src/styles/WeatherWidget.css
@@ -1,0 +1,43 @@
+.weatherWidget {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background-color: rgba(255, 255, 255, 0.9);
+  color: #333;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  max-width: 200px;
+  text-align: left;
+  z-index: 2;
+}
+
+.weatherWidget h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+}
+
+.weatherWidget .temp {
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.weatherWidget .condition {
+  margin: 0.25rem 0 0.75rem;
+  text-transform: capitalize;
+}
+
+.weatherWidget .seasonNote {
+  font-size: 0.8rem;
+  margin: 0;
+}
+
+.weatherWidget .error {
+  color: #b00020;
+}
+
+[data-theme="dark"] .weatherWidget {
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add WeatherWidget component fetching current conditions from OpenWeatherMap
- display widget in home page hero section
- style widget overlay for visibility in light and dark themes

## Testing
- `npm run lint --prefix Frontend` *(fails: 'error is defined but never used', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a9aefcfa64832494d7a61adbd11399