### PR TITLE
feat: add optional AI summarization for Sabah scraper

### DIFF
--- a/Backend/scraper.py
+++ b/Backend/scraper.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import time
 from pathlib import Path
@@ -25,6 +26,11 @@ from typing import Dict, Iterable, List, Optional
 
 import requests
 from bs4 import BeautifulSoup
+
+try:  # Optional dependency for AI summarisation
+    import google.generativeai as genai
+except Exception:  # pragma: no cover - library is optional
+    genai = None
 
 
 BASE_URL = "https://www.sabahtourism.com"
@@ -44,13 +50,41 @@ def fetch_soup(url: str) -> BeautifulSoup:
     return BeautifulSoup(response.text, "html.parser")
 
 
-def parse_attraction(url: str) -> Dict[str, Optional[str]]:
+def summarize_text(text: str) -> str:
+    """Return an AI generated summary of *text* if possible.
+
+    The function uses Google's Generative AI models if the optional
+    dependency and an API key (``GOOGLE_API_KEY`` env var) are available.
+    If not, the original text is returned unchanged.
+    """
+
+    if not text or genai is None:
+        return text
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        return text
+
+    try:  # pragma: no cover - network call
+        genai.configure(api_key=api_key)
+        model = genai.GenerativeModel("gemini-pro")
+        prompt = (
+            "Summarize the following tourist attraction description in one "
+            "concise sentence:\n" + text
+        )
+        response = model.generate_content(prompt)
+        return response.text.strip() if getattr(response, "text", None) else text
+    except Exception:
+        return text
+
+
+def parse_attraction(url: str, summarize: bool = False) -> Dict[str, Optional[str]]:
     """Parse a single attraction page.
 
     The function attempts to extract the attraction's name, description,
-    a representative image URL and the district it belongs to.  The exact
-    HTML structure of the destination pages may change over time so the
-    selectors are intentionally defensive.
+    a representative image URL and the district it belongs to.  When
+    *summarize* is ``True`` an additional short summary of the description
+    is generated via AI.
     """
 
     soup = fetch_soup(url)
@@ -65,6 +99,7 @@ def parse_attraction(url: str) -> Dict[str, Optional[str]]:
         or soup.find("article")
     )
     description = desc_tag.get_text(" ", strip=True) if desc_tag else ""
+    summary = summarize_text(description) if summarize else None
 
     # Image – pick the first image in the content
     img_tag = soup.find("img")
@@ -82,11 +117,13 @@ def parse_attraction(url: str) -> Dict[str, Optional[str]]:
         "desc": description,
         "image": image,
         "district": district,
+        "summary": summary,
     }
 
 
 def scrape_sabah_tourism(
     limit: Optional[int] = None,
+    summarize: bool = False,
 ) -> List[Dict[str, Optional[str]]]:
     """Scrape attraction data from the official Sabah Tourism page."""
 
@@ -104,7 +141,7 @@ def scrape_sabah_tourism(
             continue
 
         try:
-            data = parse_attraction(href)
+            data = parse_attraction(href, summarize=summarize)
         except requests.HTTPError:
             # Ignore pages that fail to load
             continue
@@ -133,6 +170,11 @@ def group_by_district(
                 "name": attr.get("name", ""),
                 "desc": attr.get("desc", ""),
                 "image": attr.get("image", ""),
+                **(
+                    {"summary": attr["summary"]}
+                    if attr.get("summary")
+                    else {}
+                ),
             }
         )
     return result
@@ -148,10 +190,10 @@ def save_json(
         json.dump(data, f, ensure_ascii=False, indent=2)
 
 
-def run(output: Path, limit: Optional[int] = None) -> None:
+def run(output: Path, limit: Optional[int] = None, summarize: bool = False) -> None:
     """High level helper that performs the full scraping workflow."""
 
-    attractions = scrape_sabah_tourism(limit=limit)
+    attractions = scrape_sabah_tourism(limit=limit, summarize=summarize)
     grouped = group_by_district(attractions)
     save_json(grouped, output)
 
@@ -178,11 +220,16 @@ def main(argv: Optional[List[str]] = None) -> None:
         default=None,
         help="Repeat scraping every N hours (omit to run once)",
     )
+    parser.add_argument(
+        "--summarize",
+        action="store_true",
+        help="Use AI to summarise attraction descriptions",
+    )
 
     args = parser.parse_args(argv)
 
     while True:
-        run(args.output, args.limit)
+        run(args.output, args.limit, summarize=args.summarize)
         if args.interval is None:
             break
         time.sleep(args.interval * 3600)


### PR DESCRIPTION
## Summary
- add Google Generative AI helper to create summaries of attraction descriptions
- expose `--summarize` flag to enable AI summarization when scraping

## Testing
- `python -m py_compile Backend/scraper.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adba56fb9c83249163ec1ebf1c9b39