### PR TITLE
Add Dusun dictionary page and navigation link

### DIFF
--- a/Frontend/src/App.jsx
+++ b/Frontend/src/App.jsx
@@ -12,6 +12,8 @@ import Map from "./pages/Map";
 import GamePage from "./pages/GamePage";
 import Register from "./pages/Register";
 import ExplorePage from "./pages/ExplorePage";
+import TranslatorPage from "./pages/TranslatorPage";
+import DictionaryPage from "./pages/DictionaryPage";
 
 function App() {
   return (
@@ -31,6 +33,8 @@ function App() {
           <Route path="/profile" element={<UserProfile />} />
           <Route path="/explore" element={<ExplorePage />} />
           <Route path="/explore/:districtName" element={<ExplorePage />} />
+          <Route path="/translator" element={<TranslatorPage />} />
+          <Route path="/dictionary" element={<DictionaryPage />} />
         </Routes>
       </Layout>
     </Router>

--- a/Frontend/src/components/Navbar.jsx
+++ b/Frontend/src/components/Navbar.jsx
@@ -1,31 +1,13 @@
 import { NavLink, Link } from "react-router-dom";
 import "../styles/Navbar.css";
-import { useAuth } from "../contexts/AuthContext";
 import ThemeSwitcher from "./ThemeSwitcher";
 import { FaSearch } from "react-icons/fa";
-import { useState, useRef, useEffect } from "react";
+import { useState } from "react";
 import SearchModal from "./SearchModal";
-import { FaUserCircle } from "react-icons/fa";
 import DropdownMenu from "./DropdownMenu";
 
 const Navbar = () => {
-  const { isAuthenticated } = useAuth();
-
   const [searchOpen, setSearchOpen] = useState(false);
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-
-  const dropdownRef = useRef(null);
-
-  // Close dropdown if click outside
-  useEffect(() => {
-    function handleClickOutside(event) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
-        setDropdownOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
 
   return (
     <nav className="navbar">
@@ -85,6 +67,14 @@ const Navbar = () => {
               className={({ isActive }) => (isActive ? "active" : "")}
             >
               Game
+            </NavLink>
+          </li>
+          <li>
+            <NavLink
+              to="/dictionary"
+              className={({ isActive }) => (isActive ? "active" : "")}
+            >
+              Dusun Dictionary
             </NavLink>
           </li>
           <li>

--- a/Frontend/src/pages/DictionaryPage.jsx
+++ b/Frontend/src/pages/DictionaryPage.jsx
@@ -1,0 +1,42 @@
+import React from "react";
+import "../styles/DictionaryPage.css";
+
+const phrases = [
+  { english: "hello", dusun: "Kopivosian" },
+  { english: "thank you", dusun: "Pounsikou" },
+  { english: "goodbye", dusun: "Kotohuadan" },
+  { english: "yes", dusun: "Oou" },
+  { english: "no", dusun: "Aran" },
+  { english: "excuse me", dusun: "Oduo" },
+];
+
+const tips = [
+  "Greet locals in Dusun to start conversations.",
+  "Practice a few phrases every day to build confidence.",
+  "Use our translator or chat with native speakers for feedback.",
+];
+
+const DictionaryPage = () => {
+  return (
+    <div className="dictionary-container">
+      <h1>Dusun Dictionary</h1>
+      <ul className="dictionary-list">
+        {phrases.map((p) => (
+          <li key={p.english}>
+            <strong>{p.english}:</strong> {p.dusun}
+          </li>
+        ))}
+      </ul>
+      <div className="tips">
+        <h2>Language Tips</h2>
+        <ul>
+          {tips.map((tip, index) => (
+            <li key={index}>{tip}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default DictionaryPage;

--- a/Frontend/src/pages/TranslatorPage.jsx
+++ b/Frontend/src/pages/TranslatorPage.jsx
@@ -6,6 +6,11 @@ const dictionary = {
   "thank you": "Pounsikou",
   "how are you": "Onu habar nu?",
   "good morning": "Kopivosian do tadau",
+  goodbye: "Kotohuadan",
+  please: "Ongoi",
+  yes: "Oou",
+  no: "Aran",
+  "excuse me": "Oduo",
 };
 
 const TranslatorPage = () => {
@@ -30,7 +35,9 @@ const TranslatorPage = () => {
         <button onClick={handleTranslate}>Translate</button>
       </div>
       {translation && <p className="translation">Dusun: {translation}</p>}
-      <p className="note">*Basic dictionary – more phrases coming soon!</p>
+      <p className="note">
+        *Basic dictionary – more phrases available on the Dusun Dictionary page!
+      </p>
     </div>
   );
 };

--- a/Frontend/src/styles/DictionaryPage.css
+++ b/Frontend/src/styles/DictionaryPage.css
@@ -1,0 +1,28 @@
+.dictionary-container {
+  padding: 2rem;
+  text-align: center;
+}
+
+.dictionary-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem auto;
+  max-width: 400px;
+  text-align: left;
+}
+
+.dictionary-list li {
+  margin: 0.5rem 0;
+}
+
+.tips {
+  margin-top: 2rem;
+}
+
+.tips ul {
+  list-style: disc;
+  margin: 1rem auto;
+  max-width: 400px;
+  text-align: left;
+  padding-left: 1.25rem;
+}


### PR DESCRIPTION
## Summary
- add dedicated Dusun Dictionary page with common phrases and tips for learning the language
- expand Translator with more phrases and link to the dictionary
- include dictionary in navbar and router

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: no-unused-vars in existing files)
- `npx eslint src/App.jsx src/components/Navbar.jsx src/pages/TranslatorPage.jsx src/pages/DictionaryPage.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68adc3d5a9a08324bd0661b565d7d121