### PR TITLE
feat: add guest login option

### DIFF
--- a/Frontend/src/contexts/AuthContext.jsx
+++ b/Frontend/src/contexts/AuthContext.jsx
@@ -45,11 +45,30 @@ export const AuthProvider = ({ children }) => {
     setUser(null);
   };
 
-  const value = { user, isAuthenticated: !!user, token, login, logout };
+  const loginAsGuest = () => {
+    const guestUser = {
+      name: "Guest",
+      email: "guest@example.com",
+      username: "Guest",
+    };
+    localStorage.removeItem("token");
+    setToken(null);
+    setUser(guestUser);
+  };
+
+  const value = {
+    user,
+    isAuthenticated: !!user,
+    token,
+    login,
+    loginAsGuest,
+    logout,
+  };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const useAuth = () => {
   const context = useContext(AuthContext);
   if (context === null) {

--- a/Frontend/src/pages/Login.jsx
+++ b/Frontend/src/pages/Login.jsx
@@ -9,7 +9,7 @@ const Login = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
-  const { login } = useAuth();
+  const { login, loginAsGuest } = useAuth();
   const { completeQuest, completedQuests } = useGame();
   const navigate = useNavigate();
 
@@ -26,6 +26,11 @@ const Login = () => {
     } catch (err) {
       setError(err.message || "Login failed. Please check your password.");
     }
+  };
+
+  const handleGuestLogin = () => {
+    loginAsGuest();
+    navigate("/game");
   };
 
   return (
@@ -63,6 +68,13 @@ const Login = () => {
             Log In
           </button>
         </form>
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={handleGuestLogin}
+        >
+          Continue as Guest
+        </button>
         <p className="switch-auth">
           Don't have an account? <Link to="/register">Register here</Link>
         </p>


### PR DESCRIPTION
## Summary
- add `loginAsGuest` handler in auth context and expose in provider
- introduce `Continue as Guest` button on login page that triggers guest login and redirects to game

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/pages/Login.jsx src/contexts/AuthContext.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68adc7a9fdec83249f3c58247189c986