### PR TITLE
Remove unused auth code from ExplorePage

### DIFF
--- a/Frontend/src/pages/ExplorePage.jsx
+++ b/Frontend/src/pages/ExplorePage.jsx
@@ -1,5 +1,4 @@
 import { useLocation, useParams, Link } from "react-router-dom";
-import { useAuth } from "../contexts/AuthContext";
 import { useGame } from "../contexts/GameContext";
 import "../styles/ExplorePage.css";
 
@@ -141,8 +140,8 @@ const ExplorePage = () => {
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
   const attractionQuery = searchParams.get("attraction");
-  const { isAuthenticated } = useAuth();
   const { collectStamp, collectedStamps } = useGame();
+  // Reintroduce authentication checks here if guest-specific restrictions are required.
 
   // If no districtName, show all districts
   if (!districtName) {


### PR DESCRIPTION
## Summary
- simplify ExplorePage by removing unused `useAuth` import and `isAuthenticated` destructuring
- add note on where to reintroduce auth check for guest restrictions if needed

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: several lint errors in existing files)


------
https://chatgpt.com/codex/tasks/task_e_68adc7a8d2dc8324890e00ec36a8aed2