### PR TITLE
chore: centralize API base URL

### DIFF
--- a/Frontend/src/config.js
+++ b/Frontend/src/config.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8000";

--- a/Frontend/src/contexts/AuthContext.jsx
+++ b/Frontend/src/contexts/AuthContext.jsx
@@ -1,4 +1,5 @@
 import React, { createContext, useState, useContext, useEffect } from "react";
+import { API_BASE_URL } from "../config";
 
 const AuthContext = createContext(null);
 
@@ -21,7 +22,7 @@ export const AuthProvider = ({ children }) => {
   }, [token]);
 
   const login = async (username, password) => {
-    const response = await fetch("http://localhost:5000/login", {
+    const response = await fetch(`${API_BASE_URL}/login`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ username, password }),

--- a/Frontend/src/pages/GamePage.jsx
+++ b/Frontend/src/pages/GamePage.jsx
@@ -4,6 +4,7 @@ import { useGame } from "../contexts/GameContext";
 import { quests } from "../data/quests";
 import { FaCheckCircle, FaAward, FaTicketAlt } from "react-icons/fa";
 import "../styles/GamePage.css";
+import { API_BASE_URL } from "../config";
 
 const GamePage = () => {
   const [questions, setQuestions] = useState([]);
@@ -23,7 +24,7 @@ const GamePage = () => {
 
   const fetchQuestions = async () => {
     try {
-      const response = await fetch("http://localhost:5000/quiz");
+      const response = await fetch(`${API_BASE_URL}/quiz`);
       const data = await response.json();
       setQuestions(data);
     } catch (error) {
@@ -33,7 +34,7 @@ const GamePage = () => {
 
   const fetchLeaderboard = async () => {
     try {
-      const response = await fetch("http://localhost:5000/leaderboard");
+      const response = await fetch(`${API_BASE_URL}/leaderboard`);
       const data = await response.json();
       setLeaderboard(data);
     } catch (error) {
@@ -71,7 +72,7 @@ const GamePage = () => {
   const submitScore = async (finalScore) => {
     if (!isAuthenticated) return; // Only submit if user is authenticated
     try {
-      await fetch("http://localhost:5000/scores", {
+      await fetch(`${API_BASE_URL}/scores`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/Frontend/src/pages/Register.jsx
+++ b/Frontend/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import "../styles/AuthForm.css";
+import { API_BASE_URL } from "../config";
 
 const Register = () => {
   const [username, setUsername] = useState("");
@@ -34,7 +35,7 @@ const Register = () => {
     }
 
     try {
-      const response = await fetch("http://localhost:5000/register", {
+      const response = await fetch(`${API_BASE_URL}/register`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/Frontend/src/services/aiPlannerService.js
+++ b/Frontend/src/services/aiPlannerService.js
@@ -1,4 +1,4 @@
-const API_BASE_URL = "http://localhost:8000";
+import { API_BASE_URL } from "../config";
 
 export const aiPlannerService = {
   // Generate complete itinerary


### PR DESCRIPTION
## Summary
- centralize backend API URL in a shared config
- use shared URL for auth, registration, quiz, leaderboard and planning services

## Testing
- `pytest`
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 17 errors)

------
https://chatgpt.com/codex/tasks/task_e_68ae69f5424083249a514117b6627590