### PR TITLE
feat: add hero image to explore page

### DIFF
--- a/Frontend/src/pages/ExplorePage.jsx
+++ b/Frontend/src/pages/ExplorePage.jsx
@@ -147,6 +147,11 @@ const ExplorePage = () => {
   if (!districtName) {
     return (
       <div className="explore-list">
+        <img
+          src="/backgrounds/MountKinabalu.png"
+          alt="Mount Kinabalu in Sabah"
+          className="exploreHero"
+        />
         <h2>Explore Sabah Districts</h2>
         <ul>
           {Object.keys(districts).map((name) => (
@@ -180,6 +185,11 @@ const ExplorePage = () => {
   // FIX: Use districtKey for the title instead of undefined formattedName
   return (
     <div className="explore-details">
+      <img
+        src="/backgrounds/MountKinabalu.png"
+        alt="Mount Kinabalu in Sabah"
+        className="exploreHero"
+      />
       <h2>{districtKey}</h2>
       <p>{districtData.description}</p>
       <h3>Attractions</h3>

--- a/Frontend/src/styles/ExplorePage.css
+++ b/Frontend/src/styles/ExplorePage.css
@@ -1,4 +1,10 @@
 /* Styling for ExplorePage */
+.exploreHero {
+    width: 100%;
+    max-height: 300px;
+    object-fit: cover;
+    margin-bottom: 1rem;
+}
 .header {
     height: 50vh;
     position: relative;


### PR DESCRIPTION
## Summary
- show Mount Kinabalu banner above Explore page header
- style Explore page hero image

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: no-unused-vars and react-hooks/exhaustive-deps errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9e4225d4832f9461b4ced246be2d