### PR TITLE
Add dummy user database and loader

### DIFF
--- a/Backend/app.py
+++ b/Backend/app.py
@@ -60,6 +60,28 @@ chat_sessions: Dict[str, List[Dict[str, Any]]] = {}
 user_contexts: Dict[str, Dict[str, Any]] = {}
 user_scores: Dict[str, List[Dict[str, Any]]] = {}
 
+# Load dummy user for testing purposes
+dummy_user_file = os.path.join(os.path.dirname(__file__), "data", "dummy_user.json")
+if os.path.exists(dummy_user_file):
+    try:
+        with open(dummy_user_file, "r", encoding="utf-8") as f:
+            dummy = json.load(f)
+        email = dummy.get("email")
+        if email:
+            user_id = dummy.get("user_id", str(uuid.uuid4()))
+            users_db[email] = {
+                "user_id": user_id,
+                "username": email,
+                "password": dummy.get("password", ""),
+                "created_at": dummy.get("created_at", datetime.now().isoformat()),
+                "game_progression": dummy.get("game_progression", {}),
+                "chat_history": dummy.get("chat_history", []),
+                "map": dummy.get("map", {})
+            }
+            user_scores[user_id] = dummy.get("scores", [])
+    except Exception as e:
+        print(f"Failed to load dummy user: {e}")
+
 # Pydantic models
 class UserRegister(BaseModel):
     username: str = Field(..., min_length=3, max_length=50)

--- a/Backend/data/dummy_user.json
+++ b/Backend/data/dummy_user.json
@@ -1,0 +1,19 @@
+{
+  "user_id": "00000000-0000-0000-0000-000000000001",
+  "email": "jer@jumbah.com",
+  "password": "jerjumbah",
+  "created_at": "2024-01-01T00:00:00",
+  "game_progression": {
+    "level": 1,
+    "experience": 0
+  },
+  "chat_history": [],
+  "map": {
+    "last_location": {
+      "latitude": 0,
+      "longitude": 0
+    },
+    "settings": {}
+  },
+  "scores": []
+}


### PR DESCRIPTION
## Summary
- add a JSON file with a placeholder user account for testing
- load dummy account on backend startup for authentication and progress data

## Testing
- `pytest` *(fails: Unable to obtain driver for chrome using Selenium Manager)*

------
https://chatgpt.com/codex/tasks/task_e_68c24129097483249da229c327e86769